### PR TITLE
chore: Update foundation packages to sparetools-base/2.0.4

### DIFF
--- a/packages/foundation/sparetools-cpython/conanfile.py
+++ b/packages/foundation/sparetools-cpython/conanfile.py
@@ -16,7 +16,7 @@ class CPythonToolConan(ConanFile):
     url = "https://github.com/sparesparrow/sparetools"
 
     # Use SpareTools base utilities
-    python_requires = "sparetools-base/2.0.3"
+    python_requires = "sparetools-base/2.0.4"
     python_requires_extend = "sparetools-base.SpareToolsSecurityMixin"
 
     settings = "os", "arch", "compiler", "build_type"

--- a/packages/foundation/sparetools-python-scripts/conanfile.py
+++ b/packages/foundation/sparetools-python-scripts/conanfile.py
@@ -10,6 +10,9 @@ class SparetoolsPythonScriptsConan(ConanFile):
     author = "SpareTools Team"
     topics = ("utilities", "python", "conan", "tools")
 
+    # Use SpareTools base utilities
+    python_requires = "sparetools-base/2.0.4"
+
     # This is an APPLICATION package (not python-require)
     package_type = "application"
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,5 +1,5 @@
 foundation:
-  base: 2.0.3
+  base: 2.0.4
   cpython: 3.12.7
   bootstrap: 2.0.3
   test-framework: 1.0.0


### PR DESCRIPTION
- sparetools-cpython: Update python_requires to sparetools-base/2.0.4
- sparetools-python-scripts: Add sparetools-base/2.0.4 dependency
- versions.yaml: Update base to 2.0.4 
- Ensures all foundation packages use consistent base version

Related: Foundation update initiative